### PR TITLE
move sentinel creation to ansible-init.py and look for metadata

### DIFF
--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -14,21 +14,6 @@ logging.basicConfig(level = logging.INFO, format = "[%(levelname)s] %(message)s"
 
 logger = logging.getLogger(__name__)
 
-SENTINEL_FILE_PATH = "/var/lib/ansible-init.done"
-
-def create_sentinel_file():
-    """
-    Creates a sentinel file to mark the service as executed.
-    """
-    try:
-        # Ensure the directory exists
-        os.makedirs(os.path.dirname(SENTINEL_FILE_PATH), exist_ok=True)
-        with open(SENTINEL_FILE_PATH, 'w') as f:
-            f.write("ansible-init executed")
-        logger.info("Sentinel file created at: %s", SENTINEL_FILE_PATH)
-    except Exception as e:
-        logger.error("Failed to create sentinel file: %s", e)
-
 
 def assemble_list(data, prefix):
     """
@@ -63,7 +48,7 @@ user_metadata = response.json().get("meta", {})
 logger.info("checking for ansible-init disable flag")
 if user_metadata.get("ansible_init_disable", "false").lower() == "true":
     logger.info("ansible-init is disabled via metadata. Exiting.")
-    exit(0)  # Exit early if ansible-init is disabled.
+    sys.exit(0)  # Exit early if ansible-init is disabled.
 
 
 logger.info("extracting collections and playbooks from metadata")
@@ -126,4 +111,8 @@ for playbook in playbooks:
         )
 
 
-create_sentinel_file()
+SENTINEL = pathlib.Path("/var/lib/ansible-init.done")
+
+SENTINEL.parent.mkdir(mode = o755, parents = True, exist_ok = True)
+with SENTINEL.open('w') as f:
+    f.write("ansible-init succeeded")

--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -14,7 +14,7 @@ logging.basicConfig(level = logging.INFO, format = "[%(levelname)s] %(message)s"
 
 logger = logging.getLogger(__name__)
 
-SENTINEL_FILE_PATH = /var/lib/ansible-init.done
+SENTINEL_FILE_PATH = "/var/lib/ansible-init.done"
 
 def create_sentinel_file():
     """

--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -114,5 +114,4 @@ for playbook in playbooks:
 SENTINEL = pathlib.Path("/var/lib/ansible-init.done")
 
 SENTINEL.parent.mkdir(mode = o755, parents = True, exist_ok = True)
-with SENTINEL.open('w') as f:
-    f.write("ansible-init succeeded")
+SENTINEL.touch(mode=0o644)

--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -114,7 +114,7 @@ for playbook in playbooks:
 
 logger.info("writing sentinel file /var/lib/ansible-init.done")
 SENTINEL = pathlib.Path("/var/lib/ansible-init.done")
-SENTINEL.parent.mkdir(mode = o755, parents = True, exist_ok = True)
+SENTINEL.parent.mkdir(mode = 0o755, parents = True, exist_ok = True)
 SENTINEL.touch(mode=0o644)
 
 

--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pathlib
 import subprocess
+import sys
 
 import requests
 
@@ -111,7 +112,11 @@ for playbook in playbooks:
         )
 
 
+logger.info("writing sentinel file /var/lib/ansible-init.done")
 SENTINEL = pathlib.Path("/var/lib/ansible-init.done")
-
 SENTINEL.parent.mkdir(mode = o755, parents = True, exist_ok = True)
 SENTINEL.touch(mode=0o644)
+
+
+logger.info("ansible-init completed successfully")
+

--- a/roles/linux_ansible_init/files/ansible-init.service
+++ b/roles/linux_ansible_init/files/ansible-init.service
@@ -8,7 +8,6 @@ ConditionPathExists=!/var/lib/ansible-init.done
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/bin/ansible-init
-ExecStartPost=touch /var/lib/ansible-init.done
 Restart=on-failure
 RestartSec=10
 StandardOutput=journal+console


### PR DESCRIPTION
If a packer build is run starting from an image which includes ansible-init (e.g., an “extra” build using a fatimage), then ansible-init runs during the build. This is bad because:

- In the general case it may be doing things which are not appropriate to be done during build
- It writes the sentinel file into the resulting image, which means booting a cluster instance using the resulting image never runs ansible-init

The desired fix is to prevent ansible-init running during a build, but the safest way of achieving that (without depending on e.g. how early  a cloud-init bootcmd option runs) is to change ansible-init so that if it finds a metadata flag (e.g. ansible_init_disable=true) it:

- It exits immediately without running local playbooks or remote collections 
- Doesn’t write the sentinel file