### PR TITLE
Add a timeout to the metadata fetch in ansible-init.py

### DIFF
--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -41,7 +41,7 @@ def ansible_exec(cmd, *args, **kwargs):
 
 logger.info("fetching instance metadata")
 METADATA_URL = "http://169.254.169.254/openstack/latest/meta_data.json"
-response = requests.get(METADATA_URL)
+response = requests.get(METADATA_URL, timeout=300)
 response.raise_for_status()
 user_metadata = response.json().get("meta", {})
 


### PR DESCRIPTION
Forces timeout failure and subsequent retry when ansible-init hanging on activation:

```ansible-init.service
   Loaded: loaded (/etc/systemd/system/ansible-init.service; enabled; vendor preset: disabled)
   Active: activating (start) since Mon 2024-10-21 09:21:17 UTC; 1 day 2h ago
 Main PID: 3039 (ansible-init)
    Tasks: 1 (limit: 1225048)
   Memory: 23.0M
   CGroup: /system.slice/ansible-init.service
           └─3039 /usr/lib/ansible-init/bin/python /usr/bin/ansible-init```
           
timeout set to 5 mins