### PR TITLE
Add support for Ubuntu 24.04 (Noble)

### DIFF
--- a/roles/linux_ansible_init/tasks/main.yml
+++ b/roles/linux_ansible_init/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
-
 - name: Install python venv command
   package:
     name: "{{ python3_pkg[ansible_facts['distribution'] + ansible_facts['distribution_major_version']] }}"
     # it depends:
-    # OS      package       command         python_ver
-    # ubuntu  python3-venv
-    # ubuntu  ?             python3         ?
-    # RL8     python39      python3.9       3.9.19
-    # RL9     python3       python3,python3.9 3.9.18
+    # OS        package       command           python_ver
+    # ubuntu22  python3-venv  python3           3.10.12
+    # ubuntu24  python3-venv  python3           3.12.3
+    # RL8       python39      python3.9         3.9.19
+    # RL9       python3       python3,python3.9 3.9.18
   vars:
     python3_pkg:
       Rocky8: python39
       Rocky9: python3
       Ubuntu22: python3-venv
+      Ubuntu24: python3-venv
 
 - name: Install dependencies into virtualenv
   pip:


### PR DESCRIPTION
Add support for Ubuntu 24.04 (Noble) and add information about Ubuntu Python versions to the linux_ansible_init role.

Changes tested at Graphcore with `ansible-collection-azimuth-ops` 0.12.0 and `azimuth-images` 0.15.0