### PR TITLE
prevent cyberark/conjur collection install

### DIFF
--- a/roles/linux_ansible_init/files/ansible.cfg
+++ b/roles/linux_ansible_init/files/ansible.cfg
@@ -2,3 +2,6 @@
 home = /var/lib/ansible-init
 local_tmp = /var/tmp/ansible-init
 inventory = /etc/ansible-init/inventory
+
+[galaxy]
+ignore = cyberark.conjur

--- a/roles/linux_ansible_init/files/ansible.cfg
+++ b/roles/linux_ansible_init/files/ansible.cfg
@@ -2,6 +2,3 @@
 home = /var/lib/ansible-init
 local_tmp = /var/tmp/ansible-init
 inventory = /etc/ansible-init/inventory
-
-[galaxy]
-ignore = cyberark.conjur

--- a/roles/linux_ansible_init/tasks/main.yml
+++ b/roles/linux_ansible_init/tasks/main.yml
@@ -72,5 +72,5 @@
 
 - name: Remove CyberArk Conjur collection from virtualenv
   file:
-    path: "/usr/lib/ansible-init/lib/python{{ python_version }}/site-packages/ansible_collections/cyberark"
+    path: "/usr/lib/ansible-init/lib/python{{ python_version.stdout }}/site-packages/ansible_collections/cyberark"
     state: absent

--- a/roles/linux_ansible_init/tasks/main.yml
+++ b/roles/linux_ansible_init/tasks/main.yml
@@ -60,3 +60,17 @@
     daemon_reload: yes
     name: ansible-init.service
     enabled: yes
+
+- name: Get short Python version
+  command: "/usr/lib/ansible-init/bin/{{ python3_cmds[ansible_facts['distribution']] }} -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")'"
+  register: python_version
+  changed_when: false
+  vars:
+    python3_cmds:
+      Ubuntu: python3
+      Rocky: python3.9
+
+- name: Remove CyberArk Conjur collection from virtualenv
+  file:
+    path: "/usr/lib/ansible-init/lib/python{{ python_version }}/site-packages/ansible_collections/cyberark"
+    state: absent


### PR DESCRIPTION
Prevents Trivy image scan fail due to CVE-2024-33663. Cyberark not used in ansible-init so prevented from install with default collections in ansible.
