### PR TITLE
update superlinter from known-vulnerable version

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,0 +1,7 @@
+skip-check:
+  # Requires all blocks to have rescue: - not considered appropriate
+  - CKV2_ANSIBLE_3
+  # Requires workflow files to have a top-level permissions block to ensure
+  # GITHUB_TOKEN is not write-all. azimuth-cloud org has GITHUB_TOKEN default
+  # set to read-only, so not required.
+  - CKV2_GHA_1

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,0 +1,1 @@
+../../.checkov.yaml

--- a/.github/linters/.yamllint.yml
+++ b/.github/linters/.yamllint.yml
@@ -1,0 +1,1 @@
+../../.yamllint.yml

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,0 +1,1 @@
+../../zizmor.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
         if: always()
 
       - name: Run super-linter
-        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,19 +4,12 @@ name: Lint
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-permissions:
-  contents: read
-  packages: read
-  # To report GitHub Actions status checks
-  statuses: write
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
       # To report GitHub Actions status checks
       statuses: write
 
@@ -27,6 +20,7 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@e98f9b38769d45cbe3c55a23b2eb25631babe7c4 # v25.4.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,26 +1,24 @@
 ---
-    name: Build and test PR
+name: Build and test PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+'on':
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
+    branches:
+      - main
+
+jobs:
+  lint:
     permissions:
       contents: read
-      packages: read
       # To report GitHub Actions status checks
       statuses: write
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-
-    on:
-      pull_request:
-        types:
-          - opened
-          - synchronize
-          - ready_for_review
-          - reopened
-        branches:
-          - main
-
-    jobs:
-      lint:
-        uses: ./.github/workflows/lint.yml
+    uses: ./.github/workflows/lint.yml

--- a/roles/linux_ansible_init/files/ansible-init.py
+++ b/roles/linux_ansible_init/files/ansible-init.py
@@ -90,9 +90,7 @@ for playbook in playbooks:
 logger.info("executing playbooks from /etc/ansible-init/playbooks")
 for playbook in sorted(pathlib.Path("/etc/ansible-init/playbooks").glob("*.yml")):
     logger.info("  executing playbook - %s", playbook)
-    ansible_exec(
-        "playbook", "--connection", "local", "--inventory", "127.0.0.1,", str(playbook)
-    )
+    ansible_exec("playbook", "--connection", "local", "--inventory", "127.0.0.1,", str(playbook))
 
 
 logger.info("executing remote playbooks for stage - post")

--- a/super-linter.env
+++ b/super-linter.env
@@ -1,14 +1,27 @@
+# Exclude any vendor submodules
+FILTER_REGEX_EXCLUDE=.*vendor/.*
+
 # Detect that default branch is main when running locally
 DEFAULT_BRANCH=main
 
 # Don't validate JSCPD
 VALIDATE_JSCPD=false
 
-# Don't validate JS standard because it conflicts with JS prettier
-VALIDATE_JAVASCRIPT_STANDARD=false
-
 # Don't validate Ansible because ansible-lint is more flexible
 VALIDATE_ANSIBLE=false
 
 # Don't validate YAML prettier because yamllint is sufficient
 VALIDATE_YAML_PRETTIER=false
+
+# Set to the default filename for yamllint
+YAML_CONFIG_FILE=.yamllint.yml
+
+VALIDATE_PYTHON_BLACK=false
+
+VALIDATE_BIOME_FORMAT=false
+
+VALIDATE_BIOME_LINT=false
+
+VALIDATE_TRIVY=false
+
+VALIDATE_ZIZMOR=false

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,0 +1,17 @@
+---
+
+rules:
+  secrets-outside-env:
+    # Disabled until we can allow specific secrets in
+    # 1.23.1+
+    disable: true
+    config:
+      allow:
+        - OS_CLOUDS
+        - AUTOMATION_APP_PRIVATE_KEY
+        - AUTOMATION_APP_ID
+  unpinned-uses:
+    config:
+      policies:
+        azimuth-cloud/github-actions/*: any
+        azimuth-cloud/azimuth-config/*: ref-pin


### PR DESCRIPTION
Note the equivalent ruff command for superlinter is

```
pip install ruff==0.15.8
ruff format --line-length 120
```